### PR TITLE
fix: check if target is little-endian on arm64 and wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbbf-rs"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 license = "MIT"
 description = "Split block bloom filter implementation"

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 mod aarch64;
 mod fallback;
-#[cfg(all(target_family = "wasm", target_feature = "simd128"))]
+#[cfg(all(target_family = "wasm", target_feature = "simd128", target_endian = "little"))]
 mod wasm;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod x86;
@@ -20,12 +20,12 @@ pub(crate) fn load() -> &'static dyn crate::FilterImpl {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 pub(crate) fn load() -> &'static dyn crate::FilterImpl {
     &aarch64::NeonFilter
 }
 
-#[cfg(all(target_family = "wasm", target_feature = "simd128"))]
+#[cfg(all(target_family = "wasm", target_feature = "simd128", target_endian = "little"))]
 pub(crate) fn load() -> &'static dyn crate::FilterImpl {
     &wasm::WasmFilter
 }
@@ -33,8 +33,8 @@ pub(crate) fn load() -> &'static dyn crate::FilterImpl {
 #[cfg(not(any(
     target_arch = "x86_64",
     target_arch = "x86",
-    target_arch = "aarch64",
-    all(target_family = "wasm", target_feature = "simd128")
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_family = "wasm", target_feature = "simd128", target_endian = "little")
 )))]
 pub(crate) fn load() -> &'static dyn crate::FilterImpl {
     &fallback::FallbackFilter
@@ -43,8 +43,8 @@ pub(crate) fn load() -> &'static dyn crate::FilterImpl {
 #[cfg(any(
     target_arch = "x86_64",
     target_arch = "x86",
-    target_arch = "aarch64",
-    all(target_family = "wasm", target_feature = "simd128")
+    all(target_arch = "aarch64", target_endian = "little"),
+    all(target_family = "wasm", target_feature = "simd128", target_endian = "little")
 ))]
 const SALT: [u32; 8] = [
     0x47b6137b, 0x44974d91, 0x8824ad5b, 0xa2b7289d, 0x705495c7, 0x2df1424b, 0x9efc4947, 0x5c6bfb31,


### PR DESCRIPTION
closes #10 